### PR TITLE
Refer to decision maker to do changes

### DIFF
--- a/app/views/apps/pyca-607/includes/footer.html
+++ b/app/views/apps/pyca-607/includes/footer.html
@@ -3,7 +3,6 @@
       <form method="post" class="form">
 
         <h2 class="heading-medium">Clear the Prove You Can Apply to-do</h2>
-
           <ol class="list list-number">
             <li>For the question 'Is a HRT interview required?' select 'No'.</li>
             <li>Click ‘Done’.</li>
@@ -14,6 +13,12 @@
             <li>Download the ALP.</li>
             <li>Complete the appropriate section in the ALP using the necessary evidence.</li>
             <li>Upload the ALP.</li>
+            {% if currentApp.claimantStatus == 'Refugee' %}
+              <li>For the question 'Is the claimant a refugee?', select 'Yes'.</li>
+              <li>For the question 'Have you seen a Biometric Residence Permit (BRP) for the claimant, select 'No'</li>
+            {% else %}
+              <li>For the question 'Is the claimant a refugee?', select 'No'.</li>
+            {% endif %}
             <li>For the question ‘Is this a fast-track HRT referral case?’, select ‘Yes’.</li>
             <li>Click ‘Done’.</li>
           </ol>

--- a/app/views/apps/pyca-607/index.html
+++ b/app/views/apps/pyca-607/index.html
@@ -4,10 +4,11 @@
 
 <h2 class="heading-medium">Overview</h2>
 
-<p class="lede"><p class="lede">This ticket is to make changes to the formatting of instructions on outcomes pages used in live. It is based on some alternative outcome pages we prototyped and tested with work coaches as part of PYCA-593.</p>
+<p class="lede"><p class="lede">This ticket is to make changes to the formatting of instructions on outcomes pages used in live. It is based on some alternative outcome pages we prototyped and tested with work coaches as part of PYCA-593. The changes from ticket PYCA-639 have also been included here as they required minor changes to the fast track outcome pages.</p>
 
 <ul class="list list-bullet">
 	<li><a href="https://jira.dwp.gov.uk/browse/PYCA-607">Jira Ticket with full details (PYCA-607)</a></li>
+		<li><a href="https://jira.dwp.gov.uk/browse/PYCA-639">Jira Ticket with full details (PYCA-639)</a></li>
 </ul></p>
 
 {% endblock %}


### PR DESCRIPTION
Due to the decision making around refugees, further questions have been
added to the refer to decision maker to do. This change updates our
outcome pages to tell the work coach how to answer those questions
under different circumstances.